### PR TITLE
Support numa_set_membind for tasks

### DIFF
--- a/README.in
+++ b/README.in
@@ -18,6 +18,7 @@ Code is currently maintained on GitHub:
 
 rt-app runs on GNU/Linux. It needs bash, autoconf, automake, libtool,
 libjson-c, GNU make and a recent compiler (tested on: gcc) for basic features.
+If your system has numactl (libnuma-dev) installed, numa features will be supported.  
 
 
 =================
@@ -41,18 +42,39 @@ cross-compile json-c and build both static and shared libraries for aarch64:
     make
 
 
+=================
+ BUILDING numactl
+=================
+
+If you are not happy using the version installed by your packaging system,
+if it does not provide static libraries and you need them, need to
+cross-compile, build it from source like this:
+
+retrieve source code available here:
+
+    git clone https://github.com/numactl/numactl.git
+
+cross-compile numactl and build static libraries for aarch64:
+
+    ./autogen.sh
+    ./configure --host=aarch64-linux-gnu --disable-shared --enable-static
+    make
+
+
 ================================
  BUILDING AND INSTALLING rt-app
 ================================
 
 VARIANT A)
-cross-compile a static rt-app for aarch64, using your own json-c build
+cross-compile a static rt-app for aarch64, using your own json-c and/or numactl build
 ----------------------------------------------------------------------
 (...that wasn't installed (or not into the standard locations))
 
     export ac_cv_lib_json_c_json_object_from_file=yes
+    export ac_cv_lib_numa_numa_available=yes
+    
     ./autogen.sh
-    ./configure --host=aarch64-linux-gnu LDFLAGS="-L<absolute path to json repo>" CFLAGS="-I<path to parent of json-c repo>" --with-deadline
+    ./configure --host=aarch64-linux-gnu LDFLAGS="-L<absolute path to json repo> -L<absolute path to numactl repo>" CFLAGS="-I<path to parent of json-c repo> -I<path to parent of numactl repo>" --with-deadline
     AM_LDFLAGS="-all-static" make
 
 configure supports the usual flags, like `--help` and `--prefix`, there is an
@@ -63,27 +85,28 @@ SCHED_DEADLINE.
 EXAMPLE: with a directory structure like the following:
 
     $ tree -d -L 2
-    |-- json-c
-    |   |-- autoconf-archive
-    |   |-- autom4te.cache
-    |   |-- cmake
-    |   |-- fuzz
-    |   `-- tests
-    `-- rt-app
-        |-- autom4te.cache
-        |-- build-aux
-        |-- doc
-        |-- libdl
-        |-- m4
-        `-- src
+    .
+    ├── json-c
+    │   ├── autoconf-archive
+    │   ├── cmake
+    │   ├── fuzz
+    │       └── tests
+    ├── numactl
+    │   ├── m4
+    │   └── test
+    └── rt-app
+        ├── doc
+        ├── libdl
+        └── src
 
 
 you would run:
 
     cd rt-app
     export ac_cv_lib_json_c_json_object_from_file=yes
+    export ac_cv_lib_numa_numa_available=yes
     ./autogen.sh
-    ./configure --host=aarch64-linux-gnu LDFLAGS="-L$PWD/../json-c" CFLAGS="-I$PWD/../" --with-deadline
+    ./configure --host=aarch64-linux-gnu LDFLAGS="-L$PWD/../json-c -L$PWD/../numactl" CFLAGS="-I$PWD/../" --with-deadline
     AM_LDFLAGS="-all-static" make
 
 and you should get a static rt-app executable in the src directory.

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_HEADER_STDC
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([m], [round])
 AC_CHECK_LIB([rt], [clock_gettime])
+AC_CHECK_LIB([numa], [numa_available])
 AC_CHECK_LIB([json-c], [json_object_from_file], [], [AC_MSG_ERROR([json-c libraries required])])
 AC_CHECK_FUNCS(sched_setattr, [], [])
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1046,12 +1046,7 @@ void *thread_body(void *arg)
 	/* Set numa memory binding */
 	if(data->numa_data.numaset != NULL) {
 		numa_set_membind(data->numa_data.numaset);
-		ret = numa_run_on_node_mask(data->numa_data.numaset);
 		log_notice("[%d] numa_set_membind %s \n", data->ind, data->numa_data.numaset_str);
-		if(ret != 0) {
-			perror("numa_run_on_node_mask");
-			exit(EXIT_FAILURE);
-		}
 	}
 #endif
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1042,6 +1042,18 @@ void *thread_body(void *arg)
 		perror("pthread_setname_np thread name over 16 characters");
 	}
 
+#if HAVE_LIBNUMA
+	/* Set numa memory binding */
+	if(data->numa_data.numaset != NULL) {
+		numa_set_membind(data->numa_data.numaset);
+		ret = numa_run_on_node_mask(data->numa_data.numaset);
+		if(ret != 0) {
+			perror("numa_run_on_node_mask");
+			exit(EXIT_FAILURE);
+		}
+	}
+#endif
+
 	/* Get the 1st phase's data */
 	pdata = &data->phases[0];
 

--- a/src/rt-app.c
+++ b/src/rt-app.c
@@ -1047,6 +1047,7 @@ void *thread_body(void *arg)
 	if(data->numa_data.numaset != NULL) {
 		numa_set_membind(data->numa_data.numaset);
 		ret = numa_run_on_node_mask(data->numa_data.numaset);
+		log_notice("[%d] numa_set_membind %s \n", data->ind, data->numa_data.numaset_str);
 		if(ret != 0) {
 			perror("numa_run_on_node_mask");
 			exit(EXIT_FAILURE);

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -817,6 +817,7 @@ static void parse_numa_data(struct json_object *obj, numaset_data_t *data)
 			node_idx = json_object_get_int(node);
 			if (node_idx > max_node) {
 				numa_bitmask_free(data->numaset);
+				free(data->numaset_str);
 				log_critical(PIN2 "Invalid node %u in numaset %s", node_idx, data->numaset_str);
 				exit(EXIT_INV_CONFIG);
 			}

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -796,16 +796,16 @@ static void parse_numa_data(struct json_object *obj, numaset_data_t *data)
 			log_critical(PIN2 "NUMA is not available");
 			exit(EXIT_INV_CONFIG);
 		}
-#else
-		log_critical(PIN2 "NUMA library is not configured");
-		exit(EXIT_INV_CONFIG);
-#endif
 		data->numaset = numa_parse_nodestring(data->numaset_str);
 		if(data->numaset == NULL) {
 			log_critical(PIN2 "nodestring is invalid");
 			exit(EXIT_INV_CONFIG);
 		}
 		log_info(PIN "key: nodes %s", data->numaset_str);
+#else
+		log_critical(PIN2 "NUMA library is not configured");
+		exit(EXIT_INV_CONFIG);
+#endif
 	}
 }
 

--- a/src/rt-app_parse_config.c
+++ b/src/rt-app_parse_config.c
@@ -817,8 +817,8 @@ static void parse_numa_data(struct json_object *obj, numaset_data_t *data)
 			node_idx = json_object_get_int(node);
 			if (node_idx > max_node) {
 				numa_bitmask_free(data->numaset);
-				free(data->numaset_str);
 				log_critical(PIN2 "Invalid node %u in numaset %s", node_idx, data->numaset_str);
+				free(data->numaset_str);
 				exit(EXIT_INV_CONFIG);
 			}
 			numa_bitmask_setbit(data->numaset, node_idx);

--- a/src/rt-app_types.h
+++ b/src/rt-app_types.h
@@ -23,9 +23,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define _RTAPP_TYPES_H_
 
 #include <pthread.h>
-
 #include "config.h"
 #include "dl_syscalls.h"
+
+#if HAVE_LIBNUMA
+#include <numa.h>
+#endif
 
 #define RTAPP_POLICY_DESCR_LENGTH 16
 #define RTAPP_RESOURCE_DESCR_LENGTH 16
@@ -169,6 +172,11 @@ typedef struct _cpuset_data_t {
 	size_t cpusetsize;
 } cpuset_data_t;
 
+typedef struct _numaset_data_t {
+	struct bitmask * numaset;
+	char *numaset_str;
+} numaset_data_t;
+
 typedef struct _sched_data_t {
 	policy_t policy;
 	int prio;
@@ -202,6 +210,8 @@ typedef struct _thread_data_t {
 	cpuset_data_t cpu_data; /* cpu set information */
 	cpuset_data_t *curr_cpu_data; /* Current cpu set being used */
 	cpuset_data_t def_cpu_data; /* Default cpu set for task */
+
+	numaset_data_t numa_data; /* numa interleave mask */
 
 	sched_data_t *sched_data; /* scheduler policy information */
 	sched_data_t *curr_sched_data; /* current scheduler policy */


### PR DESCRIPTION
This PR will provide basic control for task NUMA memory allocation policy.
It will help to test CONFIG_NUMA_BALANCING logic and it's interaction with CFS scheduler.
This code is integrated and tested with LISA on both arm64 and x86_64 target architectures.